### PR TITLE
(0618) style: #6 관리자-dashboard 발표 전 css 개선

### DIFF
--- a/DevQuest-service/src/main/java/com/grepp/nbe563team04/app/controller/web/admin/AdminController.java
+++ b/DevQuest-service/src/main/java/com/grepp/nbe563team04/app/controller/web/admin/AdminController.java
@@ -229,11 +229,11 @@ public class AdminController {
     }
 
 
-    // admin-dashboard Top5 Member 조회
+    // admin-dashboard Top3 Member 조회
     @GetMapping("/dashboard/top-members")
     @ResponseBody
     public List<MemberDto> getTopUsers() {
-        return memberService.getTop5MembersByLevel()
+        return memberService.getTop3MembersByLevel()
             .stream()
             .map(MemberDto::from)
             .collect(Collectors.toList());

--- a/DevQuest-service/src/main/java/com/grepp/nbe563team04/model/member/MemberInterestRepository.java
+++ b/DevQuest-service/src/main/java/com/grepp/nbe563team04/model/member/MemberInterestRepository.java
@@ -11,13 +11,13 @@ import org.springframework.stereotype.Repository;
 public interface MemberInterestRepository extends JpaRepository<MemberInterest, Long> {
 
     @Query("SELECT mi.interest.interestName FROM MemberInterest mi WHERE mi.member.userId = :userId AND mi.interest.type = 'ROLE'")
-    List<String> findTop6ByUserIdAndType(@Param("userId") Long userId);
+    List<String> findTop5ByUserIdAndType(@Param("userId") Long userId);
 
     @Query("SELECT COUNT(mi) FROM MemberInterest mi WHERE mi.interest.interestName = :interestName AND mi.interest.type = 'SKILL'")
     Integer countByInterestName(@Param("interestName") String interestName);
 
     @Query("SELECT mi.interest.interestName FROM MemberInterest mi WHERE mi.member.userId = :userId AND mi.interest.type = 'SKILL'")
-    List<String> findTop6SkillsByUserId(@Param("userId") Long userId);
+    List<String> findTop5SkillsByUserId(@Param("userId") Long userId);
 
     /**
      * 모든 활성 회원의 언어 관심도를 한 번에 조회 (N+1 문제 해결)

--- a/DevQuest-service/src/main/java/com/grepp/nbe563team04/model/member/MemberInterestService.java
+++ b/DevQuest-service/src/main/java/com/grepp/nbe563team04/model/member/MemberInterestService.java
@@ -17,9 +17,9 @@ public class MemberInterestService {
     private final MemberInterestRepository memberInterestRepository;
     private final MemberService memberService;
 
-    public List<String> getTop6Langs(String email) {
+    public List<String> getTop5Langs(String email) {
         Member member = memberService.findByEmail(email);
-        List<String> langs = memberInterestRepository.findTop6SkillsByUserId(member.getUserId());
+        List<String> langs = memberInterestRepository.findTop5SkillsByUserId(member.getUserId());
         return langs;
     }
 
@@ -33,19 +33,14 @@ public class MemberInterestService {
         return allLangs;
     }
 
-    /**
-     * 사용자의 상위 6개 언어 관심도 점수를 조회합니다.
-     * 관심도 점수는 해당 언어를 선택한 전체 사용자 수를 기준으로 계산됩니다.
-     * @param email 사용자 이메일
-     * @return 상위 6개 언어의 관심도 점수 리스트 (0-100 사이의 정수)
-     */
-    public List<Integer> getTop6LangScores(String email) {
+
+    public List<Integer> getTop5LangScores(String email) {
         Member member = memberService.findByEmail(email);
-        List<String> top6Langs = memberInterestRepository.findTop6SkillsByUserId(member.getUserId());
+        List<String> top5Langs = memberInterestRepository.findTop5SkillsByUserId(member.getUserId());
 
         long totalUsers = memberService.countActiveUsers();
 
-        List<Integer> scores = top6Langs.stream()
+        List<Integer> scores = top5Langs.stream()
             .map(lang -> {
                 Integer count = memberInterestRepository.countByInterestName(lang);
                 if (count == null || totalUsers == 0) return 0;
@@ -53,7 +48,7 @@ public class MemberInterestService {
                 return score;
             })
             .collect(Collectors.toList());
-        
+
         return scores;
     }
 }

--- a/DevQuest-service/src/main/java/com/grepp/nbe563team04/model/member/MemberRepository.java
+++ b/DevQuest-service/src/main/java/com/grepp/nbe563team04/model/member/MemberRepository.java
@@ -23,5 +23,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findAllByDeletedAtIsNull();
 
-    List<Member> findTop5ByOrderByLevelDesc();
+    List<Member> findTop3ByOrderByLevelDesc();
 }

--- a/DevQuest-service/src/main/java/com/grepp/nbe563team04/model/member/MemberService.java
+++ b/DevQuest-service/src/main/java/com/grepp/nbe563team04/model/member/MemberService.java
@@ -265,12 +265,12 @@ public class MemberService implements UserDetailsService {
         mailApi.sendMail("DevQuest-mail", "ROLE_SERVER", dto);
     }
 
-    // admin-dashbaord Top5 member 조회
-    public List<Member> getTop5MembersByLevel() {
+    // admin-dashboard Top3 member 조회
+    public List<Member> getTop3MembersByLevel() {
         return memberRepository.findAll().stream()
             .filter(member -> member.getRole() != Role.ROLE_ADMIN) // 관리자 제외
             .sorted(Comparator.comparingInt(Member::getExp).reversed())
-            .limit(5)
+            .limit(3)
             .collect(Collectors.toList());
     }
 

--- a/DevQuest-service/src/main/resources/static/css/admin/adminDashboard.css
+++ b/DevQuest-service/src/main/resources/static/css/admin/adminDashboard.css
@@ -24,7 +24,6 @@ main {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-top: 3rem;
   margin-bottom: 3rem;
 }
 
@@ -252,7 +251,7 @@ body nav.top-bar, header nav {
   max-width: unset !important;
   width: 100% !important;
   box-sizing: border-box;
-  min-height: 416px;
+  min-height: 316px;
 }
 
 .card {
@@ -581,7 +580,6 @@ canvas {
 
 
 .card-content {
-  padding: 1rem;
   position: relative;
 }
 
@@ -590,6 +588,7 @@ canvas {
   background: #f8fafc;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  min-height: 243px;
 }
 
 .summary-content {
@@ -628,8 +627,8 @@ canvas {
   justify-content: center;
   align-items: flex-start;
   gap: 2rem;
-  margin-bottom: 2rem;
   flex-wrap: wrap;
+  min-height: 295px;
 }
 
 .dashboard-summary-card,
@@ -898,7 +897,6 @@ td input[type="color"] {
 /*랭킹*/
 /*레벨 상위 유저 Top 5*/
 .top-level-card {
-  padding: 1rem;
   background: #f8fafc;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
@@ -938,19 +936,40 @@ td input[type="color"] {
 
 .profile-img {
   align-items: center;
-  width: 50px;
-  height: 50px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   object-fit: cover;
 }
 
 .card.top-level-card {
   position: relative;
-  padding-bottom: 2.5rem; /* 하단 공간 확보 */
 }
 
 .card.top-level-card .card-footer {
   position: absolute;
   right: 1rem;
   bottom: 1rem;
+}
+
+.card-header-with-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1rem 0 1rem;
+}
+
+.card-header-with-link {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.view-all-link {
+  font-size: 0.9rem;
+  color: #666;
+  text-decoration: none;
+}
+
+.view-all-link:hover {
+  text-decoration: underline;
 }

--- a/DevQuest-service/src/main/resources/templates/admin/dashboard.html
+++ b/DevQuest-service/src/main/resources/templates/admin/dashboard.html
@@ -46,15 +46,16 @@
       </div>
     </div>
 
-    <!-- 레벨 상위 유저 Top 5 -->
+    <!-- 레벨 상위 유저 Top 3 -->
     <div class="card top-level-card">
-      <div class="card-title">
-        🏆 Level Top3
+      <div class="card-header-with-link">
+        <span class="card-title">🏆 Level Top3</span>
+        <a href="/admin/member-management" class="view-all-link">전체 보기</a>
       </div>
+
       <ul class="top-user-list" id="top-user-list">
         <!-- JS가 이 안에 <li>를 동적으로 넣어줌 -->
       </ul>
-      <div class="card-footer"><a href="/admin/member-management">전체 보기</a></div>
     </div>
   </div>
 


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
	•	관리자 대시보드에서 회원 관심 태그(직무, 언어) 통계를 시각화
	•	관심 분야 칩 클릭 시 차트의 데이터 ON/OFF 가능하도록 구현
	•	레벨 Top3 카드 우측에 “전체 보기” 링크 정렬 개선

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
	•	fix: 칩 클릭 시 태그 데이터 비활성화 처리 및 색상 토글 기능 추가
	•	style: “전체 보기” 버튼을 레벨 Top3 제목 우측에 정렬되도록 CSS 수정
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
